### PR TITLE
Increase timeouts for wget, download and git clone, and upgrade ubuntu iso to 14.04.3

### DIFF
--- a/opsworks/opsworks
+++ b/opsworks/opsworks
@@ -31,9 +31,13 @@ if [[ ! -f /opt/aws/opsworks/current/VERSION ]]; then
   # download and install the requested opsworks agent
   echo "Installing OpsWorks agent version $OPSWORKS_AGENT_VERSION"
   wget -nv -O opsworks-agent-installer.tgz https://opsworks-instance-agent.s3.amazonaws.com/$OPSWORKS_AGENT_VERSION/opsworks-agent-installer.tgz
+
   tar -xzpof opsworks-agent-installer.tgz
   cd opsworks-agent-installer/opsworks-agent/bin/
   ./installer_wrapper.sh -R opsworks-instance-assets.s3.amazonaws.com
+
+  # Copy the overrides for our customizations to the agent installer
+  cp -r /tmp/opsworks/opsworks-agent-installer-overrides/* ./opsworks-agent-installer
 
   # return to our previous location and destroy our temporary directory
   popd > /dev/null

--- a/opsworks/opsworks-agent-installer-overrides/opsworks-agent/bin/downloader.sh
+++ b/opsworks/opsworks-agent-installer-overrides/opsworks-agent/bin/downloader.sh
@@ -3,8 +3,8 @@
 
 # define default values for optional parameter
 MAX_FETCH_RETRIES=8
-WGET_TIMEOUT=30
-DOWNLOAD_TIMEOUT=120
+WGET_TIMEOUT=1200
+DOWNLOAD_TIMEOUT=600
 LOG_FILE="/dev/stderr"
 DOWNLOAD_DIR_PREFIX="/tmp/opsworks-downloader"
 
@@ -19,9 +19,9 @@ USAGE_TEXT=<<EOL
       created with mktemp will be created under this path. If not given mktemp will use \$TMPDIR
    -l Absolute path to the log file. (default = /dev/stderr)
    -r Maximum number of retries. (default = 8)
-   -t Timeout for downloading files. (default = 120 seconds)
+   -t Timeout for downloading files. (default = 600 seconds)
    -u URL of the file to download.
-   -w Wget timeout, value used for the -t option of wget. (default = 30)
+   -w Wget timeout, value used for the -t option of wget. (default = 1200)
    -h Show this stuff.
 
    The script will try to download the given file and retry if it's size doesn't match

--- a/opsworks/opsworks-agent-installer-overrides/opsworks-agent/bin/downloader.sh
+++ b/opsworks/opsworks-agent-installer-overrides/opsworks-agent/bin/downloader.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# utility for downloading files with retries
+
+# define default values for optional parameter
+MAX_FETCH_RETRIES=8
+WGET_TIMEOUT=30
+DOWNLOAD_TIMEOUT=120
+LOG_FILE="/dev/stderr"
+DOWNLOAD_DIR_PREFIX="/tmp/opsworks-downloader"
+
+USAGE_TEXT=<<EOL
+
+  Usage: $0 -c <CHECKSUM_URL> -d <DOWNLOAD_DIR_PREFIX> -l <LOG_FILE>
+            -r <MAX_FETCH_RETRIES> -t <DOWNLOAD_TIMEOUT>
+            -u <TARGET_DOWNLOAD_URL> -w <WGET_TIMEOUT>
+
+   -c URL of the checksum file to download for checking file integrity. (optional)
+   -d Optional prefix for the name of the directory to download the files into. A temporary directory
+      created with mktemp will be created under this path. If not given mktemp will use \$TMPDIR
+   -l Absolute path to the log file. (default = /dev/stderr)
+   -r Maximum number of retries. (default = 8)
+   -t Timeout for downloading files. (default = 120 seconds)
+   -u URL of the file to download.
+   -w Wget timeout, value used for the -t option of wget. (default = 30)
+   -h Show this stuff.
+
+   The script will try to download the given file and retry if it's size doesn't match
+   expectations. For the instance agent the checksum file URL should be given. The script
+   will fail if the SHA-1 of the downloaded file doesn't match the one in the checksum file.
+
+   Per default a random directory in created with 'mktemp' will be used as the directory to download
+   the files into. The directory name will look like '/tmp/opsworks-downloader.XXXXXXXX'.
+
+EOL
+
+usage(){
+  echo "${USAGE_TEXT}"
+}
+
+gnu_cmd () {
+  local _gnu_cmd=''
+  local _cmd="$1"
+  local _pattern=${2:-"GNU coreutils"}
+
+  for alternative in $(which -a "${_cmd}" "g${_cmd}" "gnu${_cmd}" 2>/dev/null | uniq)
+  do
+    if [ -x "${alternative}" ] && [ -n "` ${alternative} --version | grep \"${_pattern}\"`" ]
+    then
+      _gnu_cmd="${alternative}"
+    fi
+  done
+
+  if [ "$_gnu_cmd" == '' ]
+  then
+    echo "[ERROR] GNU ${_cmd} is not installed or not found in \$PATH" >> "${LOG_FILE}"
+  else
+    echo "${_gnu_cmd}"
+  fi
+}
+
+log () {
+  local _msg="$@"
+
+  if [ -z "${gnu_date}" ]
+  then
+    gnu_date="$(gnu_cmd date)"
+  fi
+
+  echo "[ $( ${gnu_date} -u --rfc-2822 ) ] downloader: ${_msg}" >> "${LOG_FILE}"
+}
+
+# takes the prefix for the template for the mktemp command as a parameter. This must be
+# a valid path. It must not exist, but we need to have access to it.
+download_dir () {
+  if [ -z "${gnu_mktemp}" ]
+  then
+    gnu_mktemp="$(gnu_cmd mktemp)"
+  fi
+
+  local _temp_dir=$( ${gnu_mktemp} -d "${DOWNLOAD_DIR_PREFIX}.XXXXXXXX" 2>&1 )
+
+  if [ "$(echo "${_temp_dir}" | egrep -c "${DOWNLOAD_DIR_PREFIX}")" -eq '1' ]
+  then
+    log "Successfully created temporary download directory. (${_temp_dir})"
+  else
+    # $_temp_dir has the output of mktemp.
+    log "[ERROR] Failed to create temp directory. (${_temp_dir})"
+    exit 1
+  fi
+
+  DOWNLOAD_DIR="${_temp_dir}"
+}
+
+validate_input () {
+  if [ -z "${PACKAGE_URL}" ]
+  then
+    log "[ERROR] Parameter missing."
+    log "${USAGE_TEXT}"
+    exit 1
+  fi
+}
+
+initialize () {
+  COUNTER=0
+  STATUS=''
+
+  download_dir
+}
+
+file_path () {
+  local _file_url="$@"
+  local _file_name="$( echo "${_file_url}" | awk -F'/' '{print $NF}' )"
+  local _file_path="${DOWNLOAD_DIR}/${_file_name}"
+
+  echo "${_file_path}"
+}
+
+match_checksum () {
+  if [ -z "${CHECKSUM_URL}" ]
+  then
+    log "Checksum proof skipped."
+    return 0
+  else
+    if `which shasum > /dev/null 2>&1`
+    then
+      local _file=$(file_path "${PACKAGE_URL}")
+      export _file
+      # The agent's checksum file format and the output of `shasum <FILE>`, will explain this line of code.
+      $(shasum -s -a 1 -c <(awk -F'^SHA-1 ' '{print $2"  '$_file'" }' "$(file_path ${CHECKSUM_URL})"))
+
+      local _exitcode=$?
+
+      if [[ ${_exitcode} != 0 ]]
+      then
+        log "[ERROR] Checksum mismatch. (exitcode=${_exitcode})"
+      else
+        log "Checksum proof passed."
+      fi
+
+      return ${_exitcode}
+
+    else
+      log "[ERROR] shasum is not installed or not found in \$PATH"
+      exit 1
+    fi
+  fi
+}
+
+check_size () {
+  if [ -e "$(file_path "${PACKAGE_URL}" )" ]
+  then
+
+    if [ -z "${gnu_stat}" ]
+    then
+      gnu_stat="$(gnu_cmd 'stat')"
+    fi
+
+    local _actual_size=$(${gnu_stat} --format="%s" $(file_path "${PACKAGE_URL}" ))
+    local _http_headers="`curl -sI "${PACKAGE_URL}"`"
+    if [ "$?" -ne "0" ]
+    then
+      log "[ERROR] Failed to fetch content length from ${PACKAGE_URL} - curl returned exitcode $?"
+      return $?
+    fi
+
+    local _expected_size="`echo -n "${_http_headers}" | awk '/^Content-Length/ {print $2}' | tr -d '\r'`"
+
+    if [ "${_expected_size}" -eq "${_actual_size}" ]
+    then
+      log "File size test passed."
+      return 0
+    else
+      local _ix_amz_id="$(echo -n "${_http_headers}" | awk '/^x-amz-id-2/ {print $2}' | tr -d '\r')"
+      local _x_amz_request_id="$(echo -n "${_http_headers}" | awk '/^x-amz-request-id/ {print $2}' | tr -d '\r')"
+
+      log "[ERROR] File size test failed. (ix-amz-id-2: ${_ix_amz_id} - x-amz-request-id: ${_x_amz_request_id})"
+      return 1
+    fi
+  else
+    log "[ERROR] File size test failed, no file to check."
+    return 1
+  fi
+}
+
+# call it with an URL as param to download files and store them in /tmp
+wget_cmd () {
+  local _url="$1"
+
+  if [ -z "${gnu_timeout}" ]
+  then
+    gnu_timeout="$(gnu_cmd 'timeout')"
+  fi
+
+  if [ -z "${gnu_wget}" ]
+  then
+    gnu_wget=$(gnu_cmd 'wget' 'GNU Wget')
+  fi
+
+  local _timeout_cmd="${gnu_timeout} --signal=SIGTERM"
+  local _wget_cmd="${gnu_wget} -nv -T ${WGET_TIMEOUT} --directory-prefix=${DOWNLOAD_DIR}"
+
+  # download files, watch the download time using gnu timeout
+  ${_timeout_cmd} "${DOWNLOAD_TIMEOUT}" ${_wget_cmd} "${_url}" >> "${LOG_FILE}" 2>&1
+}
+
+fetch_packages () {
+  wget_cmd "${PACKAGE_URL}"
+
+  if [ -n "${CHECKSUM_URL}" ]
+  then
+    wget_cmd "${CHECKSUM_URL}"
+  fi
+}
+
+fetch_with_checksum () {
+  if [ "${COUNTER}" -lt "${MAX_FETCH_RETRIES}" ]
+  then
+    fetch_packages
+
+    # if download failed, retry.
+    local _seconds=0
+    if $(check_size) && $(match_checksum)
+    then
+     STATUS='success'
+     log "Successfully downloaded ${PACKAGE_URL}"
+    else
+       (( _seconds = $COUNTER * 5 ))
+       (( COUNTER++ ))
+       log "Retrying download after ${_seconds} seconds"
+       sleep "${_seconds}"
+
+       log "Deleting content of directory ${DOWNLOAD_DIR}"
+       rm -f ${DOWNLOAD_DIR}/*
+
+       # recursice call
+       fetch_with_checksum
+    fi
+  fi
+}
+
+downloaded_file_path () {
+  if [ "${STATUS}" == 'success' ]
+  then
+    file_path "${PACKAGE_URL}"
+  else
+    log "[ERROR] No file was downloaded."
+    return 1
+  fi
+}
+
+######
+##
+## Main block
+
+while getopts "c:d:r:l:t:u:h" optname
+do
+  case "$optname" in
+    "c")
+      # URL for the checksumm to download
+      CHECKSUM_URL="${OPTARG:-''}"
+      ;;
+    "u")
+      # URL for the package to download
+      PACKAGE_URL="${OPTARG}"
+      ;;
+    "l")
+      LOG_FILE="${OPTARG:-${LOG_FILE}}"
+      ;;
+    "r")
+      MAX_FETCH_RETRIES="${OPTARG:-${MAX_FETCH_RETRIES}}"
+      ;;
+    "t")
+      DOWNLOAD_TIMEOUT="${OPTARG:-${DOWNLOAD_TIMEOUT}}"
+      ;;
+    "d")
+      DOWNLOAD_DIR_PREFIX="${OPTARG:-${DOWNLOAD_DIR_PREFIX}}"
+      ;;
+    "w")
+      WGET_TIMEOUT="${OPTARG:-${WGET_TIMEOUT}}"
+      ;;
+    "h")
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown error while processing options"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+validate_input
+initialize
+fetch_with_checksum
+downloaded_file_path

--- a/opsworks/opsworks-agent-installer-overrides/opsworks-agent/cookbooks/deploy/definitions/opsworks_deploy.rb
+++ b/opsworks/opsworks-agent-installer-overrides/opsworks-agent/cookbooks/deploy/definitions/opsworks_deploy.rb
@@ -1,0 +1,196 @@
+define :opsworks_deploy do
+  application = params[:app]
+  deploy = params[:deploy_data]
+
+  directory "#{deploy[:deploy_to]}" do
+    group deploy[:group]
+    owner deploy[:user]
+    mode "0775"
+    action :create
+    recursive true
+  end
+
+  if deploy[:scm]
+    ensure_scm_package_installed(deploy[:scm][:scm_type])
+
+    prepare_git_checkouts(
+      :user => deploy[:user],
+      :group => deploy[:group],
+      :home => deploy[:home],
+      :ssh_key => deploy[:scm][:ssh_key]
+    ) if deploy[:scm][:scm_type].to_s == 'git'
+
+    prepare_svn_checkouts(
+      :user => deploy[:user],
+      :group => deploy[:group],
+      :home => deploy[:home],
+      :deploy => deploy,
+      :application => application
+    ) if deploy[:scm][:scm_type].to_s == 'svn'
+
+    if deploy[:scm][:scm_type].to_s == 'archive'
+      repository = prepare_archive_checkouts(deploy[:scm])
+      node.set[:deploy][application][:scm] = {
+        :scm_type => 'git',
+        :repository => repository
+      }
+    elsif deploy[:scm][:scm_type].to_s == 's3'
+      repository = prepare_s3_checkouts(deploy[:scm])
+      node.set[:deploy][application][:scm] = {
+        :scm_type => 'git',
+        :repository => repository
+      }
+    end
+  end
+
+  deploy = node[:deploy][application]
+
+  directory "#{deploy[:deploy_to]}/shared/cached-copy" do
+    recursive true
+    action :delete
+    only_if do
+      deploy[:delete_cached_copy]
+    end
+  end
+
+  ruby_block "change HOME to #{deploy[:home]} for source checkout" do
+    block do
+      ENV['HOME'] = "#{deploy[:home]}"
+    end
+  end
+
+  # setup deployment & checkout
+  if deploy[:scm] && deploy[:scm][:scm_type] != 'other'
+    Chef::Log.debug("Checking out source code of application #{application} with type #{deploy[:application_type]}")
+    deploy deploy[:deploy_to] do
+      provider Chef::Provider::Deploy.const_get(deploy[:chef_provider])
+      keep_releases deploy[:keep_releases]
+      repository deploy[:scm][:repository]
+      user deploy[:user]
+      group deploy[:group]
+      revision deploy[:scm][:revision]
+      migrate deploy[:migrate]
+      migration_command deploy[:migrate_command]
+      environment deploy[:environment].to_hash
+      purge_before_symlink(deploy[:purge_before_symlink]) unless deploy[:purge_before_symlink].nil?
+      create_dirs_before_symlink(deploy[:create_dirs_before_symlink])
+      symlink_before_migrate(deploy[:symlink_before_migrate])
+      symlinks(deploy[:symlinks]) unless deploy[:symlinks].nil?
+      action deploy[:action]
+
+      if deploy[:application_type] == 'rails' && node[:opsworks][:instance][:layers].include?('rails-app')
+        restart_command "sleep #{deploy[:sleep_before_restart]} && #{node[:opsworks][:rails_stack][:restart_command]}"
+      end
+
+      case deploy[:scm][:scm_type].to_s
+      when 'git'
+        scm_provider :git
+        enable_submodules deploy[:enable_submodules]
+        shallow_clone deploy[:shallow_clone]
+      when 'svn'
+        scm_provider :subversion
+        svn_username deploy[:scm][:user]
+        svn_password deploy[:scm][:password]
+        svn_arguments "--no-auth-cache --non-interactive --trust-server-cert"
+        svn_info_args "--no-auth-cache --non-interactive --trust-server-cert"
+      else
+        raise "unsupported SCM type #{deploy[:scm][:scm_type].inspect}"
+      end
+
+      before_migrate do
+        link_tempfiles_to_current_release
+
+        if deploy[:application_type] == 'rails'
+          if deploy[:auto_bundle_on_deploy]
+            OpsWorks::RailsConfiguration.bundle(application, node[:deploy][application], release_path)
+          end
+
+          node.default[:deploy][application][:database][:adapter] = OpsWorks::RailsConfiguration.determine_database_adapter(
+            application,
+            node[:deploy][application],
+            release_path,
+            :force => node[:force_database_adapter_detection],
+            :consult_gemfile => node[:deploy][application][:auto_bundle_on_deploy]
+          )
+          template "#{node[:deploy][application][:deploy_to]}/shared/config/database.yml" do
+            cookbook "rails"
+            source "database.yml.erb"
+            mode "0660"
+            owner node[:deploy][application][:user]
+            group node[:deploy][application][:group]
+            variables(
+              :database => node[:deploy][application][:database],
+              :environment => node[:deploy][application][:rails_env]
+            )
+
+            only_if do
+              deploy[:database][:host].present?
+            end
+          end.run_action(:create)
+        elsif deploy[:application_type] == 'aws-flow-ruby'
+          OpsWorks::RailsConfiguration.bundle(application, node[:deploy][application], release_path)
+        elsif deploy[:application_type] == 'php'
+          template "#{node[:deploy][application][:deploy_to]}/shared/config/opsworks.php" do
+            cookbook 'php'
+            source 'opsworks.php.erb'
+            mode '0660'
+            owner node[:deploy][application][:user]
+            group node[:deploy][application][:group]
+            variables(
+              :database => node[:deploy][application][:database],
+              :memcached => node[:deploy][application][:memcached],
+              :layers => node[:opsworks][:layers],
+              :stack_name => node[:opsworks][:stack][:name]
+            )
+            only_if do
+              File.exists?("#{node[:deploy][application][:deploy_to]}/shared/config")
+            end
+          end
+        elsif deploy[:application_type] == 'nodejs'
+          if deploy[:auto_npm_install_on_deploy]
+            OpsWorks::NodejsConfiguration.npm_install(application, node[:deploy][application], release_path, node[:opsworks_nodejs][:npm_install_options])
+          end
+        end
+
+        # run user provided callback file
+        run_callback_from_file("#{release_path}/deploy/before_migrate.rb")
+      end
+    end
+  end
+
+  ruby_block "change HOME back to /root after source checkout" do
+    block do
+      ENV['HOME'] = "/root"
+    end
+  end
+
+  if deploy[:application_type] == 'rails' && node[:opsworks][:instance][:layers].include?('rails-app')
+    case node[:opsworks][:rails_stack][:name]
+
+    when 'apache_passenger'
+      passenger_web_app do
+        application application
+        deploy deploy
+      end
+
+    when 'nginx_unicorn'
+      unicorn_web_app do
+        application application
+        deploy deploy
+      end
+
+    else
+      raise "Unsupport Rails stack"
+    end
+  end
+
+  template "/etc/logrotate.d/opsworks_app_#{application}" do
+    backup false
+    source "logrotate.erb"
+    cookbook 'deploy'
+    owner "root"
+    group "root"
+    mode 0644
+    variables( :log_dirs => ["#{deploy[:deploy_to]}/shared/log" ] )
+  end
+end

--- a/opsworks/opsworks-agent-installer-overrides/opsworks-agent/cookbooks/deploy/definitions/opsworks_deploy.rb
+++ b/opsworks/opsworks-agent-installer-overrides/opsworks-agent/cookbooks/deploy/definitions/opsworks_deploy.rb
@@ -77,6 +77,9 @@ define :opsworks_deploy do
       symlink_before_migrate(deploy[:symlink_before_migrate])
       symlinks(deploy[:symlinks]) unless deploy[:symlinks].nil?
       action deploy[:action]
+      # This timeout will be used by git clone
+      # We define it in stack.json, under each deploy object (vreasy and vreasy-test)
+      timeout deploy[:timeout]
 
       if deploy[:application_type] == 'rails' && node[:opsworks][:instance][:layers].include?('rails-app')
         restart_command "sleep #{deploy[:sleep_before_restart]} && #{node[:opsworks][:rails_stack][:restart_command]}"

--- a/opsworks/opsworks.rb
+++ b/opsworks/opsworks.rb
@@ -283,10 +283,14 @@ module OpsWorks
   def self.prepare_deployment(path)
     tmp_dir = Dir.mktmpdir('vagrant-opsworks')
     File.chmod(0755, tmp_dir)
-    log "Archiving repo ..."
-    `cd #{path}/. ; git archive --format tar -o #{path}/repo.tar -v HEAD . ;`
-    log "Deploying repo archive in tmp folder ..."
-    `tar -xf #{path}/repo.tar -C #{tmp_dir}; rm #{path}/repo.tar`
+    if Dir.exist?("#{path}/.git")
+      log "Archiving repo ..."
+      `cd #{path}/. ; git archive --format tar -o #{path}/repo.tar -v HEAD . ;`
+      log "Deploying repo archive in tmp folder ..."
+      `tar -xf #{path}/repo.tar -C #{tmp_dir}; rm #{path}/repo.tar`
+    else
+      FileUtils.cp_r("#{path}/.", tmp_dir)
+    end
     Dir.chdir(tmp_dir) do
       `find . -name '.git*' -exec rm -rf {} \\; 2>&1; git init; git add .; git -c user.name='Vagrant' -c user.email=none commit -m 'Create temporary repository for deployment.'`
     end

--- a/template/ubuntu1404.json
+++ b/template/ubuntu1404.json
@@ -7,10 +7,10 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "iso_urls": [
-        "http://old-releases.ubuntu.com/releases/14.04.0/ubuntu-14.04.2-server-amd64.iso",
-        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso"
+        "http://releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso",
+        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso"
       ],
-      "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
+      "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
       "iso_checksum_type": "sha1",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "30m",
@@ -37,10 +37,10 @@
       "type": "vmware-iso",
       "guest_os_type": "ubuntu-64",
       "iso_urls": [
-        "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
-        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso"
+        "http://releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso",
+        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso"
       ],
-      "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
+      "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
       "iso_checksum_type": "sha1",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",


### PR DESCRIPTION
Added an option to customize the opsworks-agent-installer by adding a folder with only the files to overwrite.
I split the commits into the first one which adds the files we want to customize but with the original files, and then a second one with the changes I did on the files, so that we can keep track of the customizations we do.

Specifically, I have
- overriden the default wget and download timeouts in downloader.sh
- added a timeout option to the deploy action that will be sent to the deploy provider. This timeout will be used by the git clone command (the provider already have this option, the only thing that lacked was the possibility to send it via an attribute on the stack.json file)


